### PR TITLE
Parse output from the repository

### DIFF
--- a/aiida_abinit/calculations.py
+++ b/aiida_abinit/calculations.py
@@ -311,7 +311,7 @@ class AbinitCalculation(CalcJob):
         # set up the calc info so AiiDA knows what to do with everything
         calcinfo = datastructures.CalcInfo()
         calcinfo.codes_info = [codeinfo]
-        calcinfo.stdin_name =  self.metadata.options.input_filename
+        calcinfo.stdin_name = self.metadata.options.input_filename
         calcinfo.stdout_name = self.metadata.options.output_filename
         calcinfo.retrieve_list = retrieve_list
         calcinfo.remote_symlink_list = remote_symlink_list


### PR DESCRIPTION
Previously, file paths pointing to locations on the remote were used in `AbinitParser` to parse outputs.
This works when the remote _is_ the local computer and those files are available, however when run on a _true_ remote computer separate from where AiiDA is run, parsing would break.

This PR implements a (hacky) workaround for finding the retrieved file paths in the repository. 

We do this because the underlying `abipy` parsers require file paths and do not accept file contents or file handles.
