### PR TITLE
Add pymatgen version requirement

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -45,6 +45,7 @@
         "abipy>=0.9.0",
         "packaging",
         "psycopg2-binary~=2.8.3",
+	"pymatgen<=2022.0.11",
         "numpy",
         "importlib_resources"
     ],


### PR DESCRIPTION
Versions of `pymatgen` later than `v2022.0.11` remove the `pymatgen.io.abiinspect` module on which `abipy` relies.

Here, I enforce a version requirement less than or equal to `v2022.0.11`.