### PR TITLE
Minor tweaks for ACWF

### DIFF
--- a/aiida_abinit/__init__.py
+++ b/aiida_abinit/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """The AiiDA plugin for ABINIT."""
 
-__version__ = '0.2.0a1'
+__version__ = '0.2.0a2'

--- a/examples/code.yml
+++ b/examples/code.yml
@@ -1,8 +1,8 @@
 ---
-label: "abinit_9.2.1"
-description: "Abinit version 9.2.1"
+label: "abinit_9.6.2"
+description: "Abinit version 9.6.2"
 input_plugin: "abinit"
 on_computer: true
-remote_abs_path: "/YOUR_PATH/abinit_9.2.1/bin/abinit"
+remote_abs_path: "/YOUR_PATH/abinit_9.6.2/bin/abinit"
 computer: "localhost"
 append_text: " "

--- a/examples/computer.yml
+++ b/examples/computer.yml
@@ -1,10 +1,10 @@
 ---
-description: "localhost-abinit"
-label: "localhost-abinit"
-hostname: "localhost-abinit"
+description: "localhost"
+label: "localhost"
+hostname: "localhost"
 transport: local
 scheduler: "direct"
-work_dir: "/home/sponce/program/aiida-abinit/tmp/.aiida_run"
+work_dir: "/home/YOUR_USERNAME/aiida-abinit/"
 mpirun_command: "mpirun -np {tot_num_mpiprocs}"
 mpiprocs_per_machine: "2"
 shebang: "#!/bin/bash"

--- a/examples/example_base.py
+++ b/examples/example_base.py
@@ -9,7 +9,7 @@ Usage: python ./example_base.py --code abinit-9.2.1-ab@localhost --pseudo_family
 import os
 
 import click
-import pymatgen as mg
+import pymatgen as pmg
 from aiida import cmdline
 from aiida.engine import run
 from aiida.orm import Float, Dict, Group, StructureData
@@ -22,7 +22,7 @@ def example_base(code, pseudo_family):
     print('Testing the AbinitBaseWorkChain single-point on Silicon')
 
     thisdir = os.path.dirname(os.path.realpath(__file__))
-    structure = StructureData(pymatgen=mg.core.Structure.from_file(os.path.join(thisdir, 'files', 'Si.cif')))
+    structure = StructureData(pymatgen=pmg.core.Structure.from_file(os.path.join(thisdir, 'files', 'Si.cif')))
     pseudo_family = Group.objects.get(label=pseudo_family)
     pseudos = pseudo_family.get_pseudos(structure=structure)
 
@@ -39,8 +39,6 @@ def example_base(code, pseudo_family):
             Dict(
                 dict={
                     'ecut': 8.0,  # Maximal kinetic energy cut-off, in Hartree
-                    'nshiftk': 4,  # of the reciprocal space (that form a BCC lattice !)
-                    'shiftk': [[0.5, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]],
                     'nstep': 20,  # Maximal number of SCF cycles
                     'toldfe': 1.0e-6,  # Will stop when, twice in a row, the difference
                     # between two consecutive evaluations of total energy

--- a/examples/example_calculation.py
+++ b/examples/example_calculation.py
@@ -29,7 +29,6 @@ def example_dft(code, pseudo_family):
     kpoints = KpointsData()
     kpoints.set_cell_from_structure(structure)
     kpoints.set_kpoints_mesh([2, 2, 2])
-    # kpoints.set_kpoints_mesh_from_density(2.0)
 
     parameters_dict = {
         'code':
@@ -44,8 +43,6 @@ def example_dft(code, pseudo_family):
         Dict(
             dict={
                 'ecut': 8.0,  # Maximal kinetic energy cut-off, in Hartree
-                'nshiftk': 4,  # of the reciprocal space (that form a BCC lattice !)
-                'shiftk': [[0.5, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]],
                 'nstep': 20,  # Maximal number of SCF cycles
                 'toldfe': 1.0e-6,  # Will stop when, twice in a row, the difference
                 # between two consecutive evaluations of total energy
@@ -58,7 +55,7 @@ def example_dft(code, pseudo_family):
                 'max_wallclock_seconds': 2 * 60,
                 'resources': {
                     'num_machines': 1,
-                    'num_mpiprocs_per_machine': 4,
+                    'num_mpiprocs_per_machine': 3,
                 }
             }
         }

--- a/examples/example_relax.py
+++ b/examples/example_relax.py
@@ -9,7 +9,7 @@ Usage: python ./example_relax.py --code abinit-9.2.1-ab@localhost --pseudo_famil
 import os
 
 import click
-import pymatgen as mg
+import pymatgen as pmg
 from aiida import cmdline
 from aiida.engine import run
 from aiida.orm import Dict, Group, Float, StructureData
@@ -22,7 +22,7 @@ def example_relax(code, pseudo_family):
     print('Testing the AbinitBaseWorkChain relaxation on Silicon')
 
     thisdir = os.path.dirname(os.path.realpath(__file__))
-    structure = StructureData(pymatgen=mg.core.Structure.from_file(os.path.join(thisdir, 'files', 'Si.cif')))
+    structure = StructureData(pymatgen=pmg.core.Structure.from_file(os.path.join(thisdir, 'files', 'Si.cif')))
     pseudo_family = Group.objects.get(label=pseudo_family)
     pseudos = pseudo_family.get_pseudos(structure=structure)
 
@@ -43,12 +43,11 @@ def example_relax(code, pseudo_family):
                     'tolmxf': 5.0e-5,  # Tolerence on the maximal force
                     'ecutsm': 0.5,  # Energy cutoff smearing, in Hartree
                     'ecut': 20.0,  # Maximal kinetic energy cut-off, in Hartree
-                    'nshiftk': 4,  # of the reciprocal space (that form a BCC lattice !)
-                    'shiftk': [[0.5, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]],
                     'nstep': 20,  # Maximal number of SCF cycles
                     'toldfe': 1.0e-6,  # Will stop when, twice in a row, the difference
                     # between two consecutive evaluations of total energy
                     # differ by less than toldfe (in Hartree)
+                    'dilatmx': 1.05
                 }
             ),
             'metadata': {

--- a/setup.json
+++ b/setup.json
@@ -53,5 +53,5 @@
     "name": "aiida-abinit",
     "python_requires": ">=3.7",
     "url": "https://github.com/sponce24/aiida-abinit",
-    "version": "0.2.0a1"
+    "version": "0.2.0a2"
 }


### PR DESCRIPTION
- Fixed examples -- they were using k-shifts, which are unsupported
- Added default input and output file names to `AbinitCalculation` which makes `inputcat` and `outputcat` commands much nicer to use
- Added some new blocked keywords related to k-points and structure information to `AbinitCalculation`
- Added an `output_structure` output to `AbinitCalculation`s which aren't doing any structural relaxation because the `abipy.core.Structure.abi_sanitize` method often significantly changes the input structure (even the number of atoms)
- Bumped the version to 0.2.0a2