### PR TITLE
Dependencies: remove upper version limit for `pymatgen`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.8, 3.9]
 
         services:
             postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,10 @@ jobs:
                 python-version: 3.8
 
         -   name: Install python dependencies
-            run:
-                pip install -e .[pre-commit,tests]
+            run: pip install -e .[pre-commit,tests]
 
         -   name: Run pre-commit
-            run:
-                pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+            run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
     tests:
 
@@ -43,13 +41,7 @@ jobs:
 
         services:
             postgres:
-                image: postgres:10
-                env:
-                    POSTGRES_DB: test_${{ matrix.backend }}
-                    POSTGRES_PASSWORD: ''
-                    POSTGRES_HOST_AUTH_METHOD: trust
-                ports:
-                -    5432:5432
+                image: postgres:12
             rabbitmq:
                 image: rabbitmq:latest
                 ports:
@@ -71,11 +63,6 @@ jobs:
             uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
-
-        -   name: Install system dependencies
-            run: |
-                sudo apt update
-                sudo apt install postgresql-12
 
         -   name: Install python dependencies
             run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -18,13 +18,7 @@ jobs:
 
         services:
             postgres:
-                image: postgres:10
-                env:
-                    POSTGRES_DB: test_${{ matrix.backend }}
-                    POSTGRES_PASSWORD: ''
-                    POSTGRES_HOST_AUTH_METHOD: trust
-                ports:
-                -    5432:5432
+                image: postgres:12
             rabbitmq:
                 image: rabbitmq:latest
                 ports:
@@ -46,11 +40,6 @@ jobs:
             uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
-
-        -   name: Install system dependencies
-            run: |
-                sudo apt update
-                sudo apt install postgresql-12
 
         -   name: Install python dependencies
             continue-on-error: true

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.8, 3.9]
 
         services:
             postgres:

--- a/setup.json
+++ b/setup.json
@@ -44,7 +44,7 @@
         "abipy>=0.8.0",
         "packaging",
         "psycopg2-binary~=2.8.3",
-	"pymatgen<=2022.0.11",
+        "pymatgen>=2022.1.20",
         "numpy",
         "importlib_resources"
     ],

--- a/setup.json
+++ b/setup.json
@@ -4,7 +4,6 @@
     "classifiers": [
         "Framework :: AiiDA",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Development Status :: 4 - Beta"
@@ -51,7 +50,7 @@
     ],
     "license": "MIT License",
     "name": "aiida-abinit",
-    "python_requires": ">=3.7",
+    "python_requires": ">=3.8",
     "url": "https://github.com/sponce24/aiida-abinit",
     "version": "0.3.0"
 }


### PR DESCRIPTION
The new lower limit of `pymatgen` no longer supports Python 3.7 (which is almost EOL  https://devguide.python.org/versions/#versions) and so we drop support for it.