### PR TITLE
DevOps: Remove `conftest.py` in root directory

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-"""pytest fixtures for simplified testing."""


### PR DESCRIPTION
It was empty, and there is a `conftest.py` in the `tests` directory already, which is where it should be.