### PR TITLE
fix aiida-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ['aiida', 'abinit']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida_core[atomic_tools]~=1.6.3,<3.0.0',
+    'aiida_core[atomic_tools]>=1.6.3,<3.0.0',
     'aiida-pseudo~=0.6.1',
     'abipy>=0.8.0',
     'packaging',


### PR DESCRIPTION
Heya, I assume this is wrong, otherwise it does not make any sense; `~=1.6.3` restricts aiida to version `1.6.x`