### PR TITLE
Fix expected output filenames when using abipy >= 0.9.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
         -   uses: actions/checkout@v2
 
         -   name: Cache Python dependencies
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
@@ -72,7 +72,7 @@ jobs:
         -   uses: actions/checkout@v2
 
         -   name: Cache Python dependencies
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        -   uses: actions/checkout@v1
+        -   uses: actions/checkout@v2
 
         -   name: Cache python dependencies
             id: cache-pip
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-pre-commit-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
         -   name: Cache python dependencies
             id: cache-pip
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -31,5 +31,5 @@ if __name__ == '__main__':
     assert args.GITHUB_REF.startswith('refs/tags/v'), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
     tag_version = args.GITHUB_REF[11:]
     package_version = get_version_from_module(Path('aiida_abinit/__init__.py').read_text(encoding='utf-8'))
-    error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'
+    error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'  # pylint: disable=invalid-name
     assert tag_version == package_version, error_message

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.1.0
     hooks:
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
@@ -15,9 +15,14 @@ repos:
         exclude: *exclude_pre_commit_hooks
 
 -   repo: https://github.com/ikamensh/flynt/
-    rev: '0.55'
+    rev: '0.76'
     hooks:
     -   id: flynt
+
+-   repo: https://github.com/pycqa/isort
+    rev: '5.12.0'
+    hooks:
+    -   id: isort
 
 -   repo: https://github.com/PyCQA/pydocstyle
     rev: 6.1.1

--- a/aiida_abinit/calculations.py
+++ b/aiida_abinit/calculations.py
@@ -3,9 +3,10 @@
 import io
 import os
 import typing as ty
+import pathlib as pl
 
 from pymatgen.io.abinit.abiobjects import structure_to_abivars
-from abipy.abio.inputs import AbinitInput
+from abipy.abio.inputs import AbinitInput, _DATA_PREFIX
 from abipy.core.structure import Structure as AbiStructure
 from abipy.data.hgh_pseudos import HGH_TABLE
 
@@ -99,9 +100,9 @@ class AbinitCalculation(CalcJob):
         spec.exit_code(100, 'ERROR_MISSING_OUTPUT_FILES',
                        message='Calculation did not produce all expected output files.')
         spec.exit_code(101, 'ERROR_MISSING_GSR_OUTPUT_FILE',
-                       message='Calculation did not produce the expected `[prefix]o_GSR.nc` output file.')
+                       message='Calculation did not produce the expected `GSR.nc` output file.')
         spec.exit_code(102, 'ERROR_MISSING_HIST_OUTPUT_FILE',
-                       message='Calculation did not produce the expected `[prefix]o_HIST.nc` output file.')
+                       message='Calculation did not produce the expected `HIST.nc` output file.')
         # Unrecoverable errors: resources like the retrieved folder or its expected contents are missing.
         spec.exit_code(200, 'ERROR_NO_RETRIEVED_FOLDER',
                        message='The retrieved folder data node could not be accessed.')
@@ -272,11 +273,11 @@ class AbinitCalculation(CalcJob):
 
         # NOTE: pop here, we don't need this setting anymore
         if not settings.pop('DRY_RUN', False):
-            # In all cases except for dry runs: o_GSR.nc
-            retrieve_list += [f'{prefix}{postfix}' for postfix in ['o_GSR.nc']]
-            # When moving ions: o_HIST.nc
+            # In all cases except for dry runs: _GSR.nc
+            retrieve_list += [f'{_DATA_PREFIX["outdata_prefix"]}{postfix}' for postfix in ['_GSR.nc']]
+            # When moving ions: _HIST.nc
             if parameters.get('ionmov', 0) > 0:
-                retrieve_list += [f'{prefix}{postfix}' for postfix in ['o_HIST.nc']]
+                retrieve_list += [f'{_DATA_PREFIX["outdata_prefix"]}{postfix}' for postfix in ['_HIST.nc']]
 
         # There may be duplicates from the `ADDITIONAL_RETRIEVE_LIST` setting, so clean up using set()
         return list(set(retrieve_list))
@@ -302,6 +303,8 @@ class AbinitCalculation(CalcJob):
 
         # Create the subfolder which will contain the pseudopotential files
         folder.get_subfolder(self._PSEUDO_SUBFOLDER, create=True)
+        for value in _DATA_PREFIX.values():
+            folder.get_subfolder(str(pl.Path(value).parent), create=True)
 
         # Generate the input file content and list of pseudopotential files to copy
         arguments = [

--- a/aiida_abinit/calculations.py
+++ b/aiida_abinit/calculations.py
@@ -2,20 +2,19 @@
 """CalcJob class for Abinit."""
 import io
 import os
-import typing as ty
 import pathlib as pl
+import typing as ty
 
-from pymatgen.io.abinit.abiobjects import structure_to_abivars
-from abipy.abio.inputs import AbinitInput, _DATA_PREFIX
+from abipy.abio.inputs import _DATA_PREFIX, AbinitInput
 from abipy.core.structure import Structure as AbiStructure
 from abipy.data.hgh_pseudos import HGH_TABLE
-
 from aiida import orm
 from aiida.common import constants, datastructures, exceptions
 from aiida.engine import CalcJob
-from aiida_pseudo.data.pseudo import Psp8Data, JthXmlData
+from aiida_pseudo.data.pseudo import JthXmlData, Psp8Data
+from pymatgen.io.abinit.abiobjects import structure_to_abivars
 
-from aiida_abinit.utils import uppercase_dict, seconds_to_timelimit
+from aiida_abinit.utils import seconds_to_timelimit, uppercase_dict
 
 
 class AbinitCalculation(CalcJob):

--- a/aiida_abinit/parsers.py
+++ b/aiida_abinit/parsers.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 """AiiDA-abinit output parser."""
-from os import path
-from tempfile import TemporaryDirectory
 import logging
+from os import path
 import pathlib as pl
+from tempfile import TemporaryDirectory
 
+from abipy import abilab
 from abipy.dynamics.hist import HistFile
 from abipy.flowtk import events
-from abipy import abilab
-import netCDF4 as nc
-import numpy as np
-from pymatgen.core import units
-
 from aiida.common.exceptions import NotExistent
 from aiida.engine import ExitCode
 from aiida.orm import BandsData, Dict, StructureData, TrajectoryData
 from aiida.parsers.parser import Parser
+import netCDF4 as nc
+import numpy as np
+from pymatgen.core import units
 
 UNITS_SUFFIX = '_units'
 DEFAULT_CHARGE_UNITS = 'e'

--- a/aiida_abinit/parsers.py
+++ b/aiida_abinit/parsers.py
@@ -8,7 +8,6 @@ import pathlib as pl
 from abipy.dynamics.hist import HistFile
 from abipy.flowtk import events
 from abipy import abilab
-from abipy.abio.inputs import _DATA_PREFIX
 import netCDF4 as nc
 import numpy as np
 from pymatgen.core import units

--- a/aiida_abinit/parsers.py
+++ b/aiida_abinit/parsers.py
@@ -3,10 +3,12 @@
 from os import path
 from tempfile import TemporaryDirectory
 import logging
+import pathlib as pl
 
 from abipy.dynamics.hist import HistFile
 from abipy.flowtk import events
 from abipy import abilab
+from abipy.abio.inputs import _DATA_PREFIX
 import netCDF4 as nc
 import numpy as np
 from pymatgen.core import units
@@ -57,7 +59,6 @@ class AbinitParser(Parser):
         optcell = parameters.get('optcell', 0)
         is_relaxation = ionmov != 0 or optcell != 0
 
-        prefix = self.node.get_attribute('prefix')
         retrieve_list = self.node.get_attribute('retrieve_list')
         output_filename = self.node.get_attribute('output_filename')
         with TemporaryDirectory() as dirpath:
@@ -73,14 +74,14 @@ class AbinitParser(Parser):
             else:
                 return self.exit_codes.ERROR_OUTPUT_MISSING
 
-            if f'{prefix}o_GSR.nc' in retrieve_list:
-                gsr_filepath = path.join(dirpath, f'{prefix}o_GSR.nc')
+            if (pl.Path(dirpath) / 'out_GSR.nc').exists():
+                gsr_filepath = path.join(dirpath, 'out_GSR.nc')
                 self._parse_gsr(gsr_filepath, is_relaxation)
             else:
                 return self.exit_codes.ERROR_MISSING_GSR_OUTPUT_FILE
 
-            if f'{prefix}o_HIST.nc' in retrieve_list:
-                hist_filepath = path.join(dirpath, f'{prefix}o_HIST.nc')
+            if (pl.Path(dirpath) / 'out_HIST.nc').exists():
+                hist_filepath = path.join(dirpath, 'out_HIST.nc')
                 self._parse_trajectory(hist_filepath)
             else:
                 if is_relaxation:

--- a/aiida_abinit/utils/dictionary.py
+++ b/aiida_abinit/utils/dictionary.py
@@ -37,8 +37,8 @@ def _case_transform_dict(dictionary: dict, dict_name: str, func_name: str, trans
         num_items = Counter(transform(str(k)) for k in dictionary.keys())
         double_keys = ','.join([k for k, v in num_items if v > 1])
         raise exceptions.InputValidationError(
-            "Inside the dictionary '{}' there are the following keys that "
-            'are repeated more than once when compared case-insensitively: {}.'
-            'This is not allowed.'.format(dict_name, double_keys)
+            f"Inside the dictionary '{dict_name}' there are the following keys that "
+            f'are repeated more than once when compared case-insensitively: {double_keys}.'
+            'This is not allowed.'
         )
     return new_dict

--- a/aiida_abinit/utils/kpoints.py
+++ b/aiida_abinit/utils/kpoints.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """k-point utility functions."""
-import numpy as np
-
 from aiida import orm
 from aiida.engine import calcfunction
+import numpy as np
 
 __all__ = ('create_kpoints_from_distance',)
 

--- a/aiida_abinit/utils/pseudos.py
+++ b/aiida_abinit/utils/pseudos.py
@@ -3,7 +3,7 @@
 import typing as ty
 
 from aiida import orm
-from aiida_pseudo.data.pseudo import Psp8Data, JthXmlData
+from aiida_pseudo.data.pseudo import JthXmlData, Psp8Data
 
 __all__ = ('validate_and_prepare_pseudos_inputs',)
 

--- a/aiida_abinit/workflows/base.py
+++ b/aiida_abinit/workflows/base.py
@@ -2,9 +2,10 @@
 """Base Abinit WorkChain implementation."""
 from aiida import orm
 from aiida.common import AttributeDict, exceptions
-from aiida.engine import (BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_)
+from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
 from aiida.plugins import CalculationFactory
-from aiida_abinit.utils import (create_kpoints_from_distance, validate_and_prepare_pseudos_inputs)
+
+from aiida_abinit.utils import create_kpoints_from_distance, validate_and_prepare_pseudos_inputs
 
 AbinitCalculation = CalculationFactory('abinit')
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,9 @@ import os
 import sys
 import time
 
-import aiida_abinit
 from aiida.manage.configuration import load_documentation_profile
+
+import aiida_abinit
 
 # -- AiiDA-related setup --------------------------------------------------
 

--- a/examples/example_base.py
+++ b/examples/example_base.py
@@ -8,11 +8,12 @@ Usage: python ./example_base.py --code abinit-9.2.1-ab@localhost --pseudo_family
 """
 import os
 
-import click
-import pymatgen as pmg
 from aiida import cmdline
 from aiida.engine import run
-from aiida.orm import Float, Dict, Group, StructureData
+from aiida.orm import Dict, Float, Group, StructureData
+import click
+import pymatgen as pmg
+
 from aiida_abinit.workflows.base import AbinitBaseWorkChain
 
 

--- a/examples/example_calculation.py
+++ b/examples/example_calculation.py
@@ -8,11 +8,12 @@ Usage: python example_dft.py --code abinit-9.2.1-ab@localhost --pseudo_family ps
 """
 import os
 
-import click
-import pymatgen as mg
 from aiida import cmdline
 from aiida.engine import run
-from aiida.orm import Dict, Group, StructureData, KpointsData
+from aiida.orm import Dict, Group, KpointsData, StructureData
+import click
+import pymatgen as mg
+
 from aiida_abinit.calculations import AbinitCalculation
 
 

--- a/examples/example_relax.py
+++ b/examples/example_relax.py
@@ -8,11 +8,12 @@ Usage: python ./example_relax.py --code abinit-9.2.1-ab@localhost --pseudo_famil
 """
 import os
 
-import click
-import pymatgen as pmg
 from aiida import cmdline
 from aiida.engine import run
-from aiida.orm import Dict, Group, Float, StructureData
+from aiida.orm import Dict, Float, Group, StructureData
+import click
+import pymatgen as pmg
+
 from aiida_abinit.workflows.base import AbinitBaseWorkChain
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ exclude = [
 line-length = 120
 fail-on-change = true
 
+[tool.isort]
+force_sort_within_sections = true
+include_trailing_comma = true
+line_length = 120
+multi_line_output = 3
+
 [tool.pydocstyle]
 ignore = [
     'D104',
@@ -93,7 +99,6 @@ generated-members = 'self.exit_codes.*'
 
 [tool.pylint.messages_control]
 disable = [
-    'bad-continuation',
     'duplicate-code',
     'locally-disabled',
     'logging-format-interpolation',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ pre-commit = [
 ]
 tests = [
     'pgtest~=1.3',
-    'pytest~=6.0',
+    'pytest>=7.0',
     'coverage[toml]',
     'pytest-cov',
     'pytest-regressions~=2.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ['aiida', 'abinit']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida_core[atomic_tools]>=2.0',
+    'aiida_core>=2.3,<2.7',
     'aiida-pseudo>=1.0',
     'abipy>=0.9.4',
     'packaging',
@@ -38,20 +38,31 @@ Source = 'https://github.com/sponce24/aiida-abinit'
 
 [project.optional-dependencies]
 docs = [
-    'sphinx',
-    'docutils',
-    'sphinx-copybutton~=0.3.0',
-    'sphinx-book-theme~=0.1.0',
-    'sphinx-click~=2.7.1'
+    'myst-nb~=1.0',
+    'jupytext>=1.11.2,<1.15.0',
+    'sphinx~=6.2.1',
+    'sphinx-copybutton~=0.5.2',
+    'sphinx-book-theme~=1.0.1',
+    'sphinx-click~=4.4.0',
+    'sphinx-design~=0.4.1',
+    'sphinxcontrib-details-directive~=0.1.0',
+    'sphinx-autoapi~=3.0.0',
+    'myst-parser~=3.0.0',
+    'sphinx-togglebutton',
 ]
 pre-commit = [
-    'pre-commit~=2.2',
-    'pylint==2.6.0'
+    'pre-commit~=2.17',
+    'pylint~=2.15.10',
+    'pylint-aiida~=0.1.1',
+    'toml'
 ]
 tests = [
     'pgtest~=1.3',
-    'pytest~=7.2',
-    'pytest-regressions~=1.0'
+    'pytest~=6.0',
+    'coverage[toml]',
+    'pytest-cov',
+    'pytest-regressions~=2.3',
+    'pytest-timeout',
 ]
 
 [project.entry-points.'aiida.calculations']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
 keywords = ['aiida', 'abinit']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida_core[atomic_tools]~=2.0',
-    'aiida-pseudo~=1.0',
-    'abipy>=0.8.0',
+    'aiida_core[atomic_tools]>=2.0',
+    'aiida-pseudo>=1.0',
+    'abipy>=0.9.4',
     'packaging',
-    'pymatgen<=v2023.9.10',
+    'pymatgen',
     'numpy',
     'importlib_resources'
 ]

--- a/tests/calculations/test_abinit.py
+++ b/tests/calculations/test_abinit.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the `AbinitCalculation` class."""
-import pytest
-
 from aiida import orm
 from aiida.common import datastructures
+import pytest
 
 
 def test_abinit_default(fixture_sandbox, generate_calc_job, generate_inputs_abinit, file_regression):
@@ -45,7 +44,7 @@ def test_abinit_default(fixture_sandbox, generate_calc_job, generate_inputs_abin
 # yapf: enable
 def test_abinit_retrieve(
     fixture_sandbox, generate_calc_job, generate_inputs_abinit, file_regression, ionmov, dry_run, retrieve_list
-):
+):  # pylint: disable=too-many-positional-arguments
     """Test an various retrieve list situations for `AbinitCalculation`."""
     entry_point_name = 'abinit'
 

--- a/tests/calculations/test_abinit.py
+++ b/tests/calculations/test_abinit.py
@@ -15,36 +15,36 @@ def test_abinit_default(fixture_sandbox, generate_calc_job, generate_inputs_abin
 
     cmdline_params = ['aiida.in', '--timelimit', '30:00']
     local_copy_list = [(psp8.uuid, psp8.filename, './pseudo/Si.psp8')]
-    retrieve_list = ['aiida.out', 'aiidao_GSR.nc']
+    retrieve_list = ['aiida.out', 'outdata/out_GSR.nc']
 
     # Check the attributes of the returned `CalcInfo`
     assert isinstance(calc_info, datastructures.CalcInfo)
     assert isinstance(calc_info.codes_info[0], datastructures.CodeInfo)
     assert calc_info.codes_info[0].cmdline_params == cmdline_params
     assert sorted(calc_info.local_copy_list) == sorted(local_copy_list)
-    assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
+    assert all(ret in calc_info.retrieve_list for ret in retrieve_list)
     assert sorted(calc_info.remote_symlink_list) == sorted([])
 
     with fixture_sandbox.open('aiida.in') as handle:
         input_written = handle.read()
 
     # Checks on the files written to the sandbox folder as raw input
-    assert sorted(fixture_sandbox.get_content_list()) == sorted(['aiida.in', 'pseudo'])
+    assert sorted(fixture_sandbox.get_content_list()) == sorted(['aiida.in', 'pseudo', 'indata', 'outdata', 'tmpdata'])
     file_regression.check(input_written, encoding='utf-8', extension='.in')
 
 
 # yapf: disable
 @pytest.mark.parametrize(
     'ionmov,dry_run,retrieve_list',
-    [(0, False, ['aiida.out', 'aiidao_GSR.nc']),
-     (2, False, ['aiida.out', 'aiidao_GSR.nc', 'aiidao_HIST.nc']),
+    [(0, False, ['aiida.out', 'outdata/out_GSR.nc']),
+     (2, False, ['aiida.out', 'outdata/out_GSR.nc', 'outdata/out_HIST.nc']),
      (0, True, ['aiida.out']),
      (2, True, ['aiida.out'])]
 )
 # yapf: enable
 def test_abinit_retrieve(
     fixture_sandbox, generate_calc_job, generate_inputs_abinit, file_regression, ionmov, dry_run, retrieve_list
-):  # pylint: disable=too-many-positional-arguments
+):  # pylint: disable=too-many-arguments
     """Test an various retrieve list situations for `AbinitCalculation`."""
     entry_point_name = 'abinit'
 
@@ -53,13 +53,13 @@ def test_abinit_retrieve(
     inputs['settings'] = orm.Dict(dict={'DRY_RUN': dry_run})
     calc_info = generate_calc_job(fixture_sandbox, entry_point_name, inputs)
 
-    assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
+    assert all(ret in calc_info.retrieve_list for ret in retrieve_list)
 
     with fixture_sandbox.open('aiida.in') as handle:
         input_written = handle.read()
 
     # Checks on the files written to the sandbox folder as raw input
-    assert sorted(fixture_sandbox.get_content_list()) == sorted(['aiida.in', 'pseudo'])
+    assert sorted(fixture_sandbox.get_content_list()) == sorted(['aiida.in', 'pseudo', 'indata', 'outdata', 'tmpdata'])
     file_regression.check(input_written, encoding='utf-8', extension='.in')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def serialize_builder():
 
     def serialize_data(data):
         # pylint: disable=too-many-return-statements
-        from aiida.orm import BaseType, Dict, AbstractCode
+        from aiida.orm import AbstractCode, BaseType, Dict
         from aiida.plugins import DataFactory
 
         StructureData = DataFactory('structure')
@@ -116,7 +116,7 @@ def serialize_builder():
 def pseudo_dojo(generate_psp8_data):
     """Create an PseudoDojo pseudo potential family from scratch."""
     from aiida.common.constants import elements
-    from aiida.plugins import GroupFactory, DataFactory
+    from aiida.plugins import DataFactory, GroupFactory
 
     PseudoDojo = GroupFactory('pseudo.family.pseudo_dojo')  # pylint: disable=invalid-name
     Psp8Data = DataFactory('pseudo.psp8')
@@ -184,15 +184,20 @@ def generate_calc_job_node(fixture_localhost):
         """Flatten inputs recursively like :meth:`aiida.engine.processes.process::Process._flatten_inputs`."""
         flat_inputs = []
         for key, value in inputs.items():
-            if isinstance(value, collections.Mapping):
+            if isinstance(value, collections.abc.Mapping):
                 flat_inputs.extend(flatten_inputs(value, prefix=prefix + key + '__'))
             else:
                 flat_inputs.append((prefix + key, value))
         return flat_inputs
 
     def _generate_calc_job_node(
-        entry_point_name='base', computer=None, test_name=None, inputs=None, attributes=None, retrieve_temporary=None
-    ):
+        entry_point_name='base',
+        computer=None,
+        test_name=None,
+        inputs=None,
+        attributes=None,
+        retrieve_temporary=None
+    ):  # pylint: disable=too-many-positional-arguments
         """Fixture to generate a mock `CalcJobNode` for testing parsers.
 
         :param entry_point_name: entry point name of the calculation class
@@ -233,10 +238,10 @@ def generate_calc_job_node(fixture_localhost):
             node.set_attribute_many(attributes)
 
         if filepath_folder:
-            from aiida.orm import StructureData
             from abipy.abio.abivars import AbinitInputFile
+            from aiida.orm import StructureData
             try:
-                parsed_input = AbinitInputFile(filepath_input)
+                parsed_input = AbinitInputFile(filepath_input)  # pylint: disable=possibly-used-before-assignment
             except FileNotFoundError:
                 pass
             else:
@@ -288,10 +293,10 @@ def generate_psp8_data():
 
     def _generate_psp8_data(element):
         """Return `Pps8Data` node."""
-        from aiida_pseudo.data.pseudo import Psp8Data
         from aiida.common.constants import elements
+        from aiida_pseudo.data.pseudo import Psp8Data
         try:
-            atomic_number = [number for number in elements if elements[number]['symbol'] == element]
+            atomic_number = [z for z, el in elements.items() if el['symbol'] == element]
             atomic_number = float(atomic_number[0])
         except IndexError as error:
             raise ValueError(f'Could not associate an atomic number to {element}.') from error
@@ -327,7 +332,7 @@ def generate_structure():
             structure.append_atom(position=[-29.3865565, 9.51707929, -4.02515904], symbols='H', name='H')
             structure.append_atom(position=[1.04074437, -1.64320127, -1.27035021], symbols='O', name='O')
         else:
-            raise KeyError('Unknown structure_id=\'{}\''.format(structure_id))
+            raise KeyError(f'Unknown structure_id=\'{structure_id}\'')
         return structure
 
     return _generate_structure
@@ -397,8 +402,8 @@ def generate_bands_data():
 
     def _generate_bands_data():
         """Return a `BandsData` instance with some basic `kpoints` and `bands` arrays."""
-        import numpy
         from aiida.plugins import DataFactory
+        import numpy
         BandsData = DataFactory('array.bands')  # pylint: disable=invalid-name
         bands_data = BandsData()
 
@@ -446,6 +451,7 @@ def generate_inputs_abinit(fixture_code, generate_structure, generate_kpoints_me
     def _generate_inputs_abinit():
         """Generate default inputs for an `AbinitCalculation."""
         from aiida.orm import Dict
+
         from aiida_abinit.utils.resources import get_default_options
 
         inputs = {
@@ -475,8 +481,8 @@ def generate_workchain_abinit(generate_workchain, generate_inputs_abinit, genera
     """Generate an instance of a `AbinitBaseWorkChain`."""
 
     def _generate_workchain_abinit(exit_code=None, inputs=None, return_inputs=False):
-        from plumpy import ProcessState
         from aiida.orm import Dict
+        from plumpy import ProcessState
 
         entry_point = 'abinit.base'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,7 @@ def generate_calc_job_node(fixture_localhost):
         inputs=None,
         attributes=None,
         retrieve_temporary=None
-    ):  # pylint: disable=too-many-positional-arguments
+    ):  # pylint: disable=too-many-arguments
         """Fixture to generate a mock `CalcJobNode` for testing parsers.
 
         :param entry_point_name: entry point name of the calculation class
@@ -241,7 +241,7 @@ def generate_calc_job_node(fixture_localhost):
             from abipy.abio.abivars import AbinitInputFile
             from aiida.orm import StructureData
             try:
-                parsed_input = AbinitInputFile(filepath_input)  # pylint: disable=possibly-used-before-assignment
+                parsed_input = AbinitInputFile(filepath_input)
             except FileNotFoundError:
                 pass
             else:


### PR DESCRIPTION
Starting from v0.9.4, AbiPy sets defaults for the `indata_prefix`, `outdata_prefix`, and `tmpdata_prefix` abivars, which changes where to expect to find the NetCDF output files (`*_GSR.nc`, `*_HIST.nc`, etc.).