### PR TITLE
Fixing some bugs

### DIFF
--- a/aiida_abinit/calculations.py
+++ b/aiida_abinit/calculations.py
@@ -191,8 +191,11 @@ class AbinitCalculation(CalcJob):
         pmg_structure = structure.get_pymatgen()
         abi_structure = AbiStructure.as_structure(pmg_structure)
         # NOTE: need to refine the `abi_sanitize` parameters
-        abi_structure = abi_structure.abi_sanitize(symprec=1e-3, angle_tolerance=5,
-            primitive=True, primitive_standard=False)
+        # Skipping: we do not want to change, at the plugin level, the structure
+        # This should be done by the user (or by the workflow) before giving it
+        # to us
+        #abi_structure = abi_structure.abi_sanitize(symprec=1e-3, angle_tolerance=5,
+        #    primitive=False, primitive_standard=False)
 
         for kind in structure.get_kind_names():
             pseudo = pseudos[kind]

--- a/aiida_abinit/workflows/base.py
+++ b/aiida_abinit/workflows/base.py
@@ -89,9 +89,21 @@ class AbinitBaseWorkChain(BaseRestartWorkChain):
         the case of the latter, the `KpointsData` will be constructed for the input `StructureData` using the
         `create_kpoints_from_distance` calculation function.
         """
+        found = False
+        found_both = False
         for key in ['kpoints', 'kpoints_distance']:
             if key in self.inputs:
-                return self.exit_codes.ERROR_INVALID_INPUT_KPOINTS # pylint: disable=no-member
+                if found:
+                    found_both = True
+                found = True
+
+        if not found:
+            self.report('Neither the `kpoints` nor the `kpoints_distance` input was specified.')
+            return self.exit_codes.ERROR_INVALID_INPUT_KPOINTS # pylint: disable=no-member
+
+        if found_both:
+            self.report('Both the `kpoints` and the `kpoints_distance` input were specified, specify only one.')
+            return self.exit_codes.ERROR_INVALID_INPUT_KPOINTS # pylint: disable=no-member
 
         try:
             kpoints = self.inputs.kpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,13 @@ classifiers = [
     'Operating System :: POSIX :: Linux',
     'Operating System :: MacOS :: MacOS X',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
 ]
 keywords = ['aiida', 'abinit']
-requires-python = '>=3.8'
+requires-python = '>=3.10'
 dependencies = [
-    'aiida_core>=2.3,<2.7',
+    'aiida_core>=2.3,<3',
     'aiida-pseudo>=1.0',
     'abipy>=0.9.4',
     'packaging',


### PR DESCRIPTION
In particular:
- the plugin is refining by default the structure. This is not a good idea: this was unexpected in my case, I wanted to simulate a perfect supercell with some magnetic moments set, and the plugin was deciding to pass only the primitive cell (with too many magnetic moments set, and apparently abinit does not complain, still it might return wrong results)
- the max compatible AiiDA version was 2.6.x, but I see no reason to block higher 2.x versions; now set to <3
- the logic in the workflow to accept one and only one between 'kpoints' and 'kpoints_distance was wrong, fixed
- The minimum python version must be 3.10 - I tried 3.9 and it does not work because abipy uses a new feature of dataclasses (kw_only) that exists only since 3.10

With these changes, I managed to run the common workflows with AiiDA-abinit